### PR TITLE
Fix unclosed code blocks.

### DIFF
--- a/2018/System.Device.Gpio/System.Device.Gpio.Proposal.md
+++ b/2018/System.Device.Gpio/System.Device.Gpio.Proposal.md
@@ -215,10 +215,17 @@ public class GpioPin : GpioConnection
 
 This class will represent anything that will be plugged into a controller and
 that is capable to read and write values. This is an extensibility point for
-future sensor-specific classes. ```C# public abstract class GpioConnection :
-IDisposable { public IDictionary<int, PinMode> Pins { get; } public void
-Write(byte[] value, int offset, int count); public int Read(byte[] buffer, int
-offset, int count); public void Dispose(); }
+future sensor-specific classes.
+
+```C#
+public abstract class GpioConnection : IDisposable
+{
+    public IDictionary<int, PinMode> Pins { get; }
+    public void Write(byte[] value, int offset, int count);
+    public int Read(byte[] buffer, int offset, int count);
+    public void Dispose();
+}
+```
 
 ### GpioDriver classes
 

--- a/2020/07-09-quick-reviews/README.md
+++ b/2020/07-09-quick-reviews/README.md
@@ -35,6 +35,8 @@ Adding the DefineScope T4-T6 for parity is approved.  If you want to add further
         public static System.Func<Microsoft.Extensions.Logging.ILogger, T1, T2, T3, T4, T5, System.IDisposable> DefineScope<T1, T2, T3, T4, T5>(string formatString) { throw null; }
         public static System.Func<Microsoft.Extensions.Logging.ILogger, T1, T2, T3, T4, T5, T6, System.IDisposable> DefineScope<T1, T2, T3, T4, T5, T6>(string formatString) { throw null; }
     }
+```
+
 ## Http header value Encoding selection
 
 **Approved** | [#runtime/38711](https://github.com/dotnet/runtime/issues/38711#issuecomment-656265904) | [Video](https://www.youtube.com/watch?v=Uu-vtMorrC0&t=0h23m21s)

--- a/2020/07-10-quick-reviews/README.md
+++ b/2020/07-10-quick-reviews/README.md
@@ -75,4 +75,5 @@ namespace System.Security.Cryptography
      {
         public static IncrementalHash CreateHMAC(HashAlgorithmName hashAlgorithm, ReadOnlySpan<byte> key);
      }
- }
+}
+```

--- a/2021/05-25-quick-reviews/README.md
+++ b/2021/05-25-quick-reviews/README.md
@@ -134,6 +134,8 @@ public class PublicKey
 +   [Obsolete("The key property is no longer recommended for use. Use the appropriate GetPublicKey method instead.")]
     public AsymmetricAlgorithm Key { get; }
 }
+```
+
 ## Add PipeWriter.UnflushedBytes
 
 **Approved** | [#runtime/48913](https://github.com/dotnet/runtime/issues/48913#issuecomment-848161253) | [Video](https://www.youtube.com/watch?v=kO1HyNmi7ww&t=0h37m2s)

--- a/2021/07-12-aspnet-reviews/README.md
+++ b/2021/07-12-aspnet-reviews/README.md
@@ -13,8 +13,10 @@
 + {
 +     public IServiceProvider? ServiceProvider { get; init; }
 -     public IReadOnlyList<string>? RouteParameterNames { get; init; }
-+    public IEnumerable<string>? RouteParameterNames { get; init; }
++     public IEnumerable<string>? RouteParameterNames { get; init; }
 + }
+```
+
 ## Capture Endpoint and RouteValues  on ExceptionHandlerFeature
 
 **Approved** | [#aspnetcore/34205](https://github.com/dotnet/aspnetcore/pull/34205)

--- a/2021/08-17-aspnet-reviews/README.md
+++ b/2021/08-17-aspnet-reviews/README.md
@@ -18,11 +18,12 @@
 +        string contentType, 
 +        params string[] otherContentTypes);
  }
+```
 
 
 * Remove `init` property setters. 
 * Remove `<returns />` doc comment for property
-* 
+
 ```diff
 +   public sealed class RequestDelegateResult
 +    {
@@ -51,9 +52,9 @@
 + ConsumesAttribute : IApiRequestMetadataProvider, IAcceptMetadata
 {
      ConsumesAttribute(string[] contentTypes);
-+   ConsumesAttribute(Type requestType, string contentType, params string[] contentTypes);
++    ConsumesAttribute(Type requestType, string contentType, params string[] contentTypes);
 
-+   Type IApiRequestMetadataProvider.RequestType { get; set; }
++    Type IApiRequestMetadataProvider.RequestType { get; set; }
 }
 ```
 

--- a/2021/08-23-aspnet-reviews/README.md
+++ b/2021/08-23-aspnet-reviews/README.md
@@ -50,6 +50,7 @@ public class AuthorizationFailureReason
 +   public string Message { get; }
 +   public IAuthorizationHandler Handler { get; }
 }
+```
 
 API consideration: Can this type be sealed and use a `IDictionary` to pass additional data instead e.g.
 

--- a/2022/01-10-aspnet-reviews/README.md
+++ b/2022/01-10-aspnet-reviews/README.md
@@ -118,7 +118,6 @@ public class ControllerBase
 +    public Func<Stream, Task> StreamWriterCallback { get; set; }
 + }
 }
-
+```
 
 We should also add PipeReader / PipeWriter overloads for controllers. @rafikiassumani-msft could we have someone propose the API for this and bring it to review?
-

--- a/2022/05-12-quick-reviews/README.md
+++ b/2022/05-12-quick-reviews/README.md
@@ -154,3 +154,4 @@ namespace System.Text.Json.Serialization.Metadata
         public JsonNumberHandling? NumberHandling { get; set; }
     }
 }
+```

--- a/2022/08-08-aspnet-reviews/README.md
+++ b/2022/08-08-aspnet-reviews/README.md
@@ -34,6 +34,8 @@ class HubConnection {
 // Up to 8
 +    public <T1, ..., T8, TResult> Subscription onWithResult(String target, FunctionSingle<T1, ..., T8, TResult> callback, Class<T1> param1, ..., Class<T8> param8);
 }
+```
+
 ## Problem uploading large files with Kestrel + Docker
 
 **NeedsWork** | [#aspnetcore/6711](https://github.com/dotnet/aspnetcore/issues/6711#issuecomment-1208537157)

--- a/2023/02-28-quick-reviews/README.md
+++ b/2023/02-28-quick-reviews/README.md
@@ -121,6 +121,7 @@ public partial class String : ISpanParsable<String>
 
     // also explicitly implement ISpanParsable
 }
+```
 
 ## MemoryExtensions.AsSpan(this string? text, Range range)
 

--- a/2023/08-03-quick-reviews/README.md
+++ b/2023/08-03-quick-reviews/README.md
@@ -140,3 +140,4 @@ namespace Microsoft.Extensions.FileProviders.Physical
     {
         // IDirectoryContents implementation
     }
+```

--- a/2024/01-16-quick-reviews/README.md
+++ b/2024/01-16-quick-reviews/README.md
@@ -58,6 +58,8 @@ namespace System.Collections.Threading.Tasks
         public bool TrySetFromTask(Task<T> completedTask);
     }
 }
+```
+
 ## Add string keyed dictionary ReadOnlySpan<char> lookup support
 
 **NeedsWork** | [#runtime/27229](https://github.com/dotnet/runtime/issues/27229#issuecomment-1894431654) | [Video](https://www.youtube.com/watch?v=StEWcIIegU4&t=0h31m53s)

--- a/2024/05-02-quick-reviews/README.md
+++ b/2024/05-02-quick-reviews/README.md
@@ -57,6 +57,7 @@ public partial class MetadataBuilder
 +        int guidHeapStartOffset = 0,
 +        Func<int, BlobBuilder>? createBlobBuilderFunc = null);
 }
+```
 
 ## TypeDescriptor-related trimming support
 


### PR DESCRIPTION
This PR fixes the Markdown files that have code blocks that were not closed (because their respective issues had), which resulted in weird formatting.

I identified these blocks by searching for ` ``` ` and inspecting the files with an odd number of occurrences.

### Before

![image](https://github.com/dotnet/apireviews/assets/12659251/ff5d7204-8900-4fbd-b9e6-61a3e876886c)

### After

![image](https://github.com/dotnet/apireviews/assets/12659251/7b4763d1-5e03-443e-aedd-6224950cef32)
